### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.2.0] - 2025-09-18
+
+### Added
+- No provided key class
+- String converstion in query parameters fix. Addressing [#15](https://github.com/Flightradar24/fr24api-sdk-python/issues/15) 
+
+[0.2.0]: https://github.com/flightradar24/fr24api-sdk-python/releases/tag/v0.1.0
+
 ## [0.1.0] - 2025-08-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fr24sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK for the Flightradar24 API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/fr24sdk/__init__.py
+++ b/src/fr24sdk/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 """Flightradar24 API SDK for Python."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from .client import Client
 

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "fr24sdk"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Release PR to release:
- https://github.com/Flightradar24/fr24api-sdk-python/pull/14
- https://github.com/Flightradar24/fr24api-sdk-python/pull/16 (fixing https://github.com/Flightradar24/fr24api-sdk-python/issues/15)
