### PR TITLE
Harden httpx Client usage to reduce network resource consumption in long-lived clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ without a custom `http_client`:
 | Pool limits | 10 max connections, 5 keepalive, 120 s expiry | Caps socket usage, prevents unbounded pool growth |
 | TCP keepalive | `SO_KEEPALIVE` + tuned `KEEPIDLE`/`INTVL`/`CNT` | Detects dead peers, prevents stale NAT/firewall entries |
 | Connect retries | 2 | Survives transient DNS and TCP connect failures |
-| Granular timeout | connect=10 s, read=30 s, write=10 s, pool=5 s | Fails fast on connect/pool stalls instead of blocking 30 s |
+| Granular timeout | connect=5 s, read=30 s, write=10 s, pool=5 s | Fails fast on connect/pool stalls instead of blocking 30 s |
 
 All of these are configurable:
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,33 @@ client = Client()
 client.close()
 ```
 
+### 7. Connection Management for Long-Running Processes
+
+The SDK configures conservative connection pool limits by default (`max_connections=10`, `max_keepalive_connections=5`, `keepalive_expiry=5s`). These defaults are suitable for most workloads and help prevent resource accumulation on constrained devices.
+
+You can customize pool limits via `httpx.Limits`:
+
+```python
+import httpx
+from fr24sdk.client import Client
+
+client = Client(limits=httpx.Limits(max_connections=3, max_keepalive_connections=1, keepalive_expiry=5))
+```
+
+For long-running processes (e.g., continuous monitoring scripts), you can periodically recycle the connection pool without recreating the client:
+
+```python
+client = Client()
+request_count = 0
+while True:
+    result = client.flight_summary.get_light(callsigns=["..."])
+    request_count += 1
+    if request_count % 1000 == 0:
+        client.reset()  # Recycle the connection pool
+```
+
+> **Note:** `reset()` is not thread-safe and must not be called while requests are in-flight. It is not supported when a custom `http_client` was provided to the constructor.
+
 ## Contributing
 
 Contributions are welcome! Please see `CONTRIBUTING.md` for guidelines.

--- a/README.md
+++ b/README.md
@@ -173,18 +173,32 @@ client.close()
 
 ### 7. Connection Management for Long-Running Processes
 
-The SDK configures conservative connection pool limits by default (`max_connections=10`, `max_keepalive_connections=5`, `keepalive_expiry=5s`). These defaults are suitable for most workloads and help prevent resource accumulation on constrained devices.
+The SDK is hardened out of the box for long-lived use on resource-constrained
+devices.  The defaults below apply automatically when you create a `Client()`
+without a custom `http_client`:
 
-You can customize pool limits via `httpx.Limits`:
+| Setting | Default | Purpose |
+|---|---|---|
+| Pool limits | 10 max connections, 5 keepalive, 120 s expiry | Caps socket usage, prevents unbounded pool growth |
+| TCP keepalive | `SO_KEEPALIVE` + tuned `KEEPIDLE`/`INTVL`/`CNT` | Detects dead peers, prevents stale NAT/firewall entries |
+| Connect retries | 2 | Survives transient DNS and TCP connect failures |
+| Granular timeout | connect=10 s, read=30 s, write=10 s, pool=5 s | Fails fast on connect/pool stalls instead of blocking 30 s |
+
+All of these are configurable:
 
 ```python
 import httpx
 from fr24sdk.client import Client
 
-client = Client(limits=httpx.Limits(max_connections=3, max_keepalive_connections=1, keepalive_expiry=5))
+client = Client(
+    limits=httpx.Limits(max_connections=3, max_keepalive_connections=1),
+    timeout=httpx.Timeout(connect=5, read=60, write=10, pool=3),
+    retries=3,
+)
 ```
 
-For long-running processes (e.g., continuous monitoring scripts), you can periodically recycle the connection pool without recreating the client:
+For long-running processes (e.g., continuous monitoring scripts), you can
+periodically recycle the connection pool without recreating the client:
 
 ```python
 from datetime import datetime, timedelta, timezone
@@ -203,7 +217,10 @@ while True:
         client.reset()  # Recycle the connection pool
 ```
 
-> **Note:** `reset()` is not thread-safe and must not be called while requests are in-flight. It is not supported when a custom `http_client` was provided to the constructor.
+> **Note:** `reset()` is not thread-safe and must not be called while requests
+> are in-flight.  It is not supported when a custom `http_client` was provided
+> to the constructor.  Avoid calling it too frequently — each reset closes all
+> pooled connections, which temporarily increases reconnect and TIME_WAIT churn.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -187,10 +187,17 @@ client = Client(limits=httpx.Limits(max_connections=3, max_keepalive_connections
 For long-running processes (e.g., continuous monitoring scripts), you can periodically recycle the connection pool without recreating the client:
 
 ```python
+from datetime import datetime, timedelta, timezone
+
 client = Client()
 request_count = 0
 while True:
-    result = client.flight_summary.get_light(callsigns=["..."])
+    now = datetime.now(timezone.utc)
+    result = client.flight_summary.get_light(
+        callsigns=["..."],
+        flight_datetime_from=now - timedelta(hours=1),
+        flight_datetime_to=now,
+    )
     request_count += 1
     if request_count % 1000 == 0:
         client.reset()  # Recycle the connection pool

--- a/src/fr24sdk/client.py
+++ b/src/fr24sdk/client.py
@@ -32,6 +32,7 @@ class Client:
         api_version: Optional[str] = None,
         timeout: Optional[float] = None,
         http_client: Optional[httpx.Client] = None,
+        limits: Optional[httpx.Limits] = None,
     ):
         """Initializes the Flightradar24 API Client.
 
@@ -41,6 +42,9 @@ class Client:
             api_version: The API version. Defaults to 'v1'.
             timeout: Request timeout in seconds. Defaults to 30s.
             http_client: An optional pre-configured httpx.Client instance.
+            limits: Connection pool limits (an ``httpx.Limits`` instance).
+                Defaults to conservative limits suitable for most workloads.
+                Ignored when ``http_client`` is provided.
         """
         transport_kwargs: dict[str, Any] = {}
         if api_token is not None:
@@ -53,6 +57,8 @@ class Client:
             transport_kwargs["timeout"] = timeout
         if http_client is not None:
             transport_kwargs["http_client"] = http_client
+        if limits is not None:
+            transport_kwargs["limits"] = limits
 
         self._transport = HttpTransport(**transport_kwargs)
 
@@ -72,6 +78,23 @@ class Client:
         if self._transport:
             self._transport.close()
             logger.info("Flightradar24 Client transport closed.")
+
+    def reset(self) -> None:
+        """Recycles the underlying HTTP connection pool.
+
+        Closes idle connections and creates a fresh pool with the same
+        configuration.  Useful for long-running processes on
+        resource-constrained devices where periodic recycling prevents
+        socket accumulation.
+
+        Not thread-safe — do not call while requests are in-flight.
+
+        Raises:
+            RuntimeError: If the client was created with a
+                user-supplied ``http_client``.
+        """
+        self._transport.reset()
+        logger.info("Flightradar24 Client connection pool reset.")
 
     def __enter__(self) -> "Client":
         return self

--- a/src/fr24sdk/client.py
+++ b/src/fr24sdk/client.py
@@ -42,7 +42,7 @@ class Client:
             base_url: The base URL for the API. Defaults to production API.
             api_version: The API version. Defaults to 'v1'.
             timeout: Request timeout in seconds (``float``) or a granular
-                ``httpx.Timeout`` instance.  Defaults to connect=10s,
+                ``httpx.Timeout`` instance.  Defaults to connect=5s,
                 read=30s, write=10s, pool=5s.
             http_client: An optional pre-configured httpx.Client instance.
                 When provided, ``limits``, ``retries``, and socket-level

--- a/src/fr24sdk/client.py
+++ b/src/fr24sdk/client.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 """Main synchronous client for interacting with the Flightradar24 API."""
 
-from typing import Optional, Any
+from typing import Optional, Any, Union
 import logging
 
 import httpx
@@ -30,9 +30,10 @@ class Client:
         api_token: Optional[str] = None,
         base_url: Optional[str] = None,
         api_version: Optional[str] = None,
-        timeout: Optional[float] = None,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
         http_client: Optional[httpx.Client] = None,
         limits: Optional[httpx.Limits] = None,
+        retries: Optional[int] = None,
     ):
         """Initializes the Flightradar24 API Client.
 
@@ -40,11 +41,19 @@ class Client:
             api_token: Your Flightradar24 API token. If None, reads from FR24_API_TOKEN env var.
             base_url: The base URL for the API. Defaults to production API.
             api_version: The API version. Defaults to 'v1'.
-            timeout: Request timeout in seconds. Defaults to 30s.
+            timeout: Request timeout in seconds (``float``) or a granular
+                ``httpx.Timeout`` instance.  Defaults to connect=10s,
+                read=30s, write=10s, pool=5s.
             http_client: An optional pre-configured httpx.Client instance.
+                When provided, ``limits``, ``retries``, and socket-level
+                hardening are bypassed — the caller owns the full
+                transport configuration.
             limits: Connection pool limits (an ``httpx.Limits`` instance).
                 Defaults to conservative limits suitable for most workloads.
                 Ignored when ``http_client`` is provided.
+            retries: Number of connection-establishment retries (covers DNS
+                and TCP connect failures).  Defaults to 2.  Ignored when
+                ``http_client`` is provided.
         """
         transport_kwargs: dict[str, Any] = {}
         if api_token is not None:
@@ -59,6 +68,8 @@ class Client:
             transport_kwargs["http_client"] = http_client
         if limits is not None:
             transport_kwargs["limits"] = limits
+        if retries is not None:
+            transport_kwargs["retries"] = retries
 
         self._transport = HttpTransport(**transport_kwargs)
 

--- a/src/fr24sdk/transport.py
+++ b/src/fr24sdk/transport.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_BASE_URL = "https://fr24api.flightradar24.com"
 DEFAULT_API_VERSION = "v1"
 DEFAULT_USER_AGENT = f"FR24 API Python SDK/{__version__}"
-DEFAULT_TIMEOUT = httpx.Timeout(connect=10, read=30, write=10, pool=5)
+DEFAULT_TIMEOUT = httpx.Timeout(connect=5, read=30, write=10, pool=5)
 DEFAULT_POOL_LIMITS = httpx.Limits(
     max_connections=10,
     max_keepalive_connections=5,
@@ -83,6 +83,11 @@ class HttpTransport:
         self._owns_client: bool = http_client is None
 
         self._client: httpx.Client = http_client or self._build_client()
+
+    @property
+    def timeout(self) -> Union[float, httpx.Timeout]:
+        """The configured request timeout."""
+        return self._timeout
 
     def _build_client(self) -> httpx.Client:
         """Construct an httpx.Client with the transport's pool, retry, and socket settings."""
@@ -231,6 +236,9 @@ class HttpTransport:
         where periodic connection pool recycling can prevent socket
         accumulation. Not thread-safe — do not call while requests are
         in-flight.
+
+        May be called after :meth:`close` — the transport will be
+        reopened with the original configuration.
 
         Raises:
             RuntimeError: If the transport was created with a

--- a/src/fr24sdk/transport.py
+++ b/src/fr24sdk/transport.py
@@ -4,6 +4,7 @@
 """Handles low-level HTTP communication with the Flightradar24 API."""
 
 import os
+import socket
 import logging
 from typing import Any, Optional, Union, Mapping, Sequence, Type
 
@@ -25,13 +26,34 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "https://fr24api.flightradar24.com"
 DEFAULT_API_VERSION = "v1"
-DEFAULT_TIMEOUT_SECONDS = 30
 DEFAULT_USER_AGENT = f"FR24 API Python SDK/{__version__}"
+DEFAULT_TIMEOUT = httpx.Timeout(connect=10, read=30, write=10, pool=5)
 DEFAULT_POOL_LIMITS = httpx.Limits(
     max_connections=10,
     max_keepalive_connections=5,
-    keepalive_expiry=5,
+    keepalive_expiry=120,
 )
+DEFAULT_RETRIES = 2
+
+
+def _build_socket_options() -> list[tuple[int, int, int]]:
+    """Build TCP socket options for connection health monitoring.
+
+    Enables SO_KEEPALIVE and, where available, tunes the kernel's
+    keepalive probing so dead peers and stale NAT/firewall entries are
+    detected without waiting for the next application-level request.
+    """
+    options: list[tuple[int, int, int]] = [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    ]
+    # TCP keepalive tuning — constants vary by OS; only set when available.
+    if hasattr(socket, "TCP_KEEPIDLE"):
+        options.append((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60))
+    if hasattr(socket, "TCP_KEEPINTVL"):
+        options.append((socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10))
+    if hasattr(socket, "TCP_KEEPCNT"):
+        options.append((socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3))
+    return options
 
 
 class HttpTransport:
@@ -42,9 +64,10 @@ class HttpTransport:
         api_token: Optional[str] = None,
         base_url: str = DEFAULT_BASE_URL,
         api_version: str = DEFAULT_API_VERSION,
-        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        timeout: Union[float, httpx.Timeout] = DEFAULT_TIMEOUT,
         http_client: Optional[httpx.Client] = None,
         limits: Optional[httpx.Limits] = None,
+        retries: int = DEFAULT_RETRIES,
     ):
         self.api_token = api_token or os.environ.get("FR24_API_TOKEN")
         if not self.api_token:
@@ -54,14 +77,24 @@ class HttpTransport:
 
         self.base_url = base_url
         self.api_version = api_version
-        self.timeout = timeout
+        self._timeout = timeout
         self._limits = limits or DEFAULT_POOL_LIMITS
+        self._retries = retries
         self._owns_client: bool = http_client is None
 
-        self._client: httpx.Client = http_client or httpx.Client(
-            base_url=self.base_url,
-            timeout=self.timeout,
+        self._client: httpx.Client = http_client or self._build_client()
+
+    def _build_client(self) -> httpx.Client:
+        """Construct an httpx.Client with the transport's pool, retry, and socket settings."""
+        transport = httpx.HTTPTransport(
             limits=self._limits,
+            retries=self._retries,
+            socket_options=_build_socket_options(),
+        )
+        return httpx.Client(
+            transport=transport,
+            base_url=self.base_url,
+            timeout=self._timeout,
         )
 
     def _get_default_headers(self) -> dict[str, str]:
@@ -211,11 +244,7 @@ class HttpTransport:
                 "Client instead."
             )
         self.close()
-        self._client = httpx.Client(
-            base_url=self.base_url,
-            timeout=self.timeout,
-            limits=self._limits,
-        )
+        self._client = self._build_client()
         logger.debug("HTTP connection pool reset.")
 
     def __enter__(self) -> "HttpTransport":

--- a/src/fr24sdk/transport.py
+++ b/src/fr24sdk/transport.py
@@ -27,6 +27,11 @@ DEFAULT_BASE_URL = "https://fr24api.flightradar24.com"
 DEFAULT_API_VERSION = "v1"
 DEFAULT_TIMEOUT_SECONDS = 30
 DEFAULT_USER_AGENT = f"FR24 API Python SDK/{__version__}"
+DEFAULT_POOL_LIMITS = httpx.Limits(
+    max_connections=10,
+    max_keepalive_connections=5,
+    keepalive_expiry=5,
+)
 
 
 class HttpTransport:
@@ -39,6 +44,7 @@ class HttpTransport:
         api_version: str = DEFAULT_API_VERSION,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
         http_client: Optional[httpx.Client] = None,
+        limits: Optional[httpx.Limits] = None,
     ):
         self.api_token = api_token or os.environ.get("FR24_API_TOKEN")
         if not self.api_token:
@@ -49,10 +55,13 @@ class HttpTransport:
         self.base_url = base_url
         self.api_version = api_version
         self.timeout = timeout
+        self._limits = limits or DEFAULT_POOL_LIMITS
+        self._owns_client: bool = http_client is None
 
         self._client: httpx.Client = http_client or httpx.Client(
             base_url=self.base_url,
             timeout=self.timeout,
+            limits=self._limits,
         )
 
     def _get_default_headers(self) -> dict[str, str]:
@@ -181,6 +190,33 @@ class HttpTransport:
         """Closes the underlying HTTP client."""
         if hasattr(self, "_client") and self._client and not self._client.is_closed:
             self._client.close()
+
+    def reset(self) -> None:
+        """Closes the current HTTP client and creates a fresh one.
+
+        Useful for long-running processes on resource-constrained devices
+        where periodic connection pool recycling can prevent socket
+        accumulation. Not thread-safe — do not call while requests are
+        in-flight.
+
+        Raises:
+            RuntimeError: If the transport was created with a
+                user-supplied ``http_client``, since the SDK cannot
+                safely recreate an externally-configured client.
+        """
+        if not self._owns_client:
+            raise RuntimeError(
+                "Cannot reset a transport that was created with a "
+                "user-supplied http_client. Close and recreate the "
+                "Client instead."
+            )
+        self.close()
+        self._client = httpx.Client(
+            base_url=self.base_url,
+            timeout=self.timeout,
+            limits=self._limits,
+        )
+        logger.debug("HTTP connection pool reset.")
 
     def __enter__(self) -> "HttpTransport":
         return self

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -7,7 +7,7 @@ import pytest
 import httpx
 
 from fr24sdk.client import Client
-from fr24sdk.transport import DEFAULT_POOL_LIMITS
+from fr24sdk.transport import DEFAULT_POOL_LIMITS, DEFAULT_RETRIES, DEFAULT_TIMEOUT
 
 
 TEST_TOKEN = "test_api_token_123"
@@ -54,4 +54,46 @@ def test_client_reset_raises_for_user_provided_http_client():
     with pytest.raises(RuntimeError, match="user-supplied http_client"):
         client.reset()
     assert not user_client.is_closed
+    client.close()
+
+
+def test_client_default_retries_passthrough():
+    """Client applies default connection-establishment retries."""
+    client = Client(api_token=TEST_TOKEN)
+    assert client.transport._client._transport._pool._retries == DEFAULT_RETRIES
+    client.close()
+
+
+def test_client_custom_retries_passthrough():
+    """Client forwards custom retries to the transport."""
+    client = Client(api_token=TEST_TOKEN, retries=5)
+    assert client.transport._client._transport._pool._retries == 5
+    client.close()
+
+
+def test_client_default_granular_timeout():
+    """Client applies the SDK's granular timeout defaults."""
+    client = Client(api_token=TEST_TOKEN)
+    t = client.transport._client.timeout
+    assert t == DEFAULT_TIMEOUT
+    client.close()
+
+
+def test_client_float_timeout_passthrough():
+    """Client accepts a plain float timeout for backwards compat."""
+    client = Client(api_token=TEST_TOKEN, timeout=42.0)
+    t = client.transport._client.timeout
+    assert t.connect == 42.0
+    assert t.read == 42.0
+    client.close()
+
+
+def test_client_httpx_timeout_passthrough():
+    """Client accepts an httpx.Timeout object."""
+    custom = httpx.Timeout(connect=1, read=2, write=3, pool=4)
+    client = Client(api_token=TEST_TOKEN, timeout=custom)
+    t = client.transport._client.timeout
+    assert t.connect == 1
+    assert t.read == 2
+    assert t.pool == 4
     client.close()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright Flightradar24
+#
+# SPDX-License-Identifier: MIT
+"""Unit tests for the Client class."""
+
+import pytest
+import httpx
+
+from fr24sdk.client import Client
+from fr24sdk.transport import DEFAULT_POOL_LIMITS
+
+
+TEST_TOKEN = "test_api_token_123"
+
+
+def test_client_default_limits_passthrough():
+    """Client applies SDK default pool limits to its transport."""
+    client = Client(api_token=TEST_TOKEN)
+    pool = client.transport._client._transport._pool
+    assert pool._max_connections == DEFAULT_POOL_LIMITS.max_connections
+    assert pool._max_keepalive_connections == DEFAULT_POOL_LIMITS.max_keepalive_connections
+    assert pool._keepalive_expiry == DEFAULT_POOL_LIMITS.keepalive_expiry
+    client.close()
+
+
+def test_client_custom_limits_passthrough():
+    """Client forwards custom limits to the transport."""
+    custom = httpx.Limits(max_connections=2, max_keepalive_connections=1, keepalive_expiry=1)
+    client = Client(api_token=TEST_TOKEN, limits=custom)
+    pool = client.transport._client._transport._pool
+    assert pool._max_connections == 2
+    assert pool._max_keepalive_connections == 1
+    assert pool._keepalive_expiry == 1
+    client.close()
+
+
+def test_client_reset_recycles_pool():
+    """Client.reset() replaces the underlying httpx.Client."""
+    client = Client(api_token=TEST_TOKEN)
+    old_http_client = client.transport._client
+
+    client.reset()
+
+    assert old_http_client.is_closed
+    assert not client.transport._client.is_closed
+    assert client.transport._client is not old_http_client
+    client.close()
+
+
+def test_client_reset_raises_for_user_provided_http_client():
+    """Client.reset() raises when constructed with an external http_client."""
+    user_client = httpx.Client(base_url="http://example.com")
+    client = Client(api_token=TEST_TOKEN, http_client=user_client)
+    with pytest.raises(RuntimeError, match="user-supplied http_client"):
+        client.reset()
+    assert not user_client.is_closed
+    client.close()

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -15,6 +15,7 @@ from fr24sdk.transport import (
     DEFAULT_API_VERSION,
     DEFAULT_TIMEOUT_SECONDS,
     DEFAULT_USER_AGENT,
+    DEFAULT_POOL_LIMITS,
 )
 from fr24sdk.exceptions import (
     ApiError,
@@ -329,3 +330,93 @@ def test_transport_explicit_close() -> None:  # respx_router fixture removed
 
     assert route.called
     assert raw_client_passed_to_transport.is_closed
+
+
+# --- Connection pool limits tests ---
+
+
+def test_default_pool_limits_applied():
+    """When no http_client or limits are given, SDK defaults are applied."""
+    trans = HttpTransport(api_token=TEST_TOKEN)
+    pool = trans._client._transport._pool
+    assert pool._max_connections == DEFAULT_POOL_LIMITS.max_connections
+    assert pool._max_keepalive_connections == DEFAULT_POOL_LIMITS.max_keepalive_connections
+    assert pool._keepalive_expiry == DEFAULT_POOL_LIMITS.keepalive_expiry
+    trans.close()
+
+
+def test_custom_limits_applied():
+    """User-supplied limits override the defaults."""
+    custom_limits = httpx.Limits(
+        max_connections=3, max_keepalive_connections=1, keepalive_expiry=2
+    )
+    trans = HttpTransport(api_token=TEST_TOKEN, limits=custom_limits)
+    pool = trans._client._transport._pool
+    assert pool._max_connections == 3
+    assert pool._max_keepalive_connections == 1
+    assert pool._keepalive_expiry == 2
+    trans.close()
+
+
+def test_user_provided_http_client_ignores_limits():
+    """When http_client is provided, limits param is irrelevant."""
+    user_client = httpx.Client(
+        base_url="http://example.com",
+        limits=httpx.Limits(max_connections=42),
+    )
+    custom_limits = httpx.Limits(max_connections=1)
+    trans = HttpTransport(
+        api_token=TEST_TOKEN, http_client=user_client, limits=custom_limits
+    )
+    # The user's client should be used as-is
+    assert trans._client is user_client
+    assert trans._client._transport._pool._max_connections == 42
+    trans.close()
+
+
+# --- reset() tests ---
+
+
+@respx_mock
+def test_reset_creates_new_working_client():
+    """reset() closes the old client and creates a functional replacement."""
+    trans = HttpTransport(api_token=TEST_TOKEN)
+    old_client = trans._client
+
+    trans.reset()
+
+    assert old_client.is_closed
+    assert not trans._client.is_closed
+    assert trans._client is not old_client
+
+    # New client should be functional
+    route = respx_mock.get(FULL_TEST_URL).respond(200, json={"ok": True})
+    response = trans.request("GET", TEST_API_ENDPOINT_PATH)
+    assert response.status_code == 200
+    assert route.called
+    trans.close()
+
+
+def test_reset_preserves_pool_limits():
+    """reset() re-applies the same pool limits to the new client."""
+    custom_limits = httpx.Limits(
+        max_connections=7, max_keepalive_connections=2, keepalive_expiry=3
+    )
+    trans = HttpTransport(api_token=TEST_TOKEN, limits=custom_limits)
+    trans.reset()
+    pool = trans._client._transport._pool
+    assert pool._max_connections == 7
+    assert pool._max_keepalive_connections == 2
+    assert pool._keepalive_expiry == 3
+    trans.close()
+
+
+def test_reset_raises_for_user_provided_client():
+    """reset() raises RuntimeError when the transport uses an external client."""
+    user_client = httpx.Client(base_url="http://example.com")
+    trans = HttpTransport(api_token=TEST_TOKEN, http_client=user_client)
+    with pytest.raises(RuntimeError, match="user-supplied http_client"):
+        trans.reset()
+    # Original client should still be usable
+    assert not user_client.is_closed
+    trans.close()

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -79,7 +79,7 @@ def test_transport_initialization_defaults():
     assert trans.api_token == TEST_TOKEN
     assert trans.base_url == DEFAULT_BASE_URL
     assert trans.api_version == DEFAULT_API_VERSION
-    assert trans._timeout == DEFAULT_TIMEOUT
+    assert trans.timeout == DEFAULT_TIMEOUT
     assert isinstance(trans._client, httpx.Client)
     trans.close()
 
@@ -98,7 +98,7 @@ def test_transport_initialization_custom_values():
     assert trans.api_token == "custom_token"
     assert trans.base_url == custom_base_url
     assert trans.api_version == custom_api_version
-    assert trans._timeout == custom_timeout
+    assert trans.timeout == custom_timeout
     trans.close()
 
 
@@ -466,7 +466,7 @@ def test_granular_timeout_default():
     """Default timeout uses granular connect/read/write/pool values."""
     trans = HttpTransport(api_token=TEST_TOKEN)
     client_timeout = trans._client.timeout
-    assert client_timeout.connect == 10
+    assert client_timeout.connect == 5
     assert client_timeout.read == 30
     assert client_timeout.write == 10
     assert client_timeout.pool == 5

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -452,6 +452,13 @@ def test_socket_options_include_keepalive():
     sock_opts = pool._socket_options
     # SO_KEEPALIVE must always be present
     assert (_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1) in sock_opts
+    # TCP keepalive tuning constants should be present when the platform supports them
+    if hasattr(_socket, "TCP_KEEPIDLE"):
+        assert (_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 60) in sock_opts
+    if hasattr(_socket, "TCP_KEEPINTVL"):
+        assert (_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10) in sock_opts
+    if hasattr(_socket, "TCP_KEEPCNT"):
+        assert (_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3) in sock_opts
     trans.close()
 
 

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -13,9 +13,10 @@ from fr24sdk.transport import (
     HttpTransport,
     DEFAULT_BASE_URL,
     DEFAULT_API_VERSION,
-    DEFAULT_TIMEOUT_SECONDS,
+    DEFAULT_TIMEOUT,
     DEFAULT_USER_AGENT,
     DEFAULT_POOL_LIMITS,
+    DEFAULT_RETRIES,
 )
 from fr24sdk.exceptions import (
     ApiError,
@@ -78,7 +79,7 @@ def test_transport_initialization_defaults():
     assert trans.api_token == TEST_TOKEN
     assert trans.base_url == DEFAULT_BASE_URL
     assert trans.api_version == DEFAULT_API_VERSION
-    assert trans.timeout == DEFAULT_TIMEOUT_SECONDS
+    assert trans._timeout == DEFAULT_TIMEOUT
     assert isinstance(trans._client, httpx.Client)
     trans.close()
 
@@ -97,7 +98,7 @@ def test_transport_initialization_custom_values():
     assert trans.api_token == "custom_token"
     assert trans.base_url == custom_base_url
     assert trans.api_version == custom_api_version
-    assert trans.timeout == custom_timeout
+    assert trans._timeout == custom_timeout
     trans.close()
 
 
@@ -419,4 +420,79 @@ def test_reset_raises_for_user_provided_client():
         trans.reset()
     # Original client should still be usable
     assert not user_client.is_closed
+    trans.close()
+
+
+# --- Connection hardening tests ---
+
+
+def test_default_retries_configured():
+    """SDK-created clients use connection-establishment retries."""
+    trans = HttpTransport(api_token=TEST_TOKEN)
+    # retries are set on the HTTPTransport, which is _client._transport
+    http_transport = trans._client._transport
+    assert isinstance(http_transport, httpx.HTTPTransport)
+    assert http_transport._pool._retries == DEFAULT_RETRIES
+    trans.close()
+
+
+def test_custom_retries():
+    """User can override the retry count."""
+    trans = HttpTransport(api_token=TEST_TOKEN, retries=5)
+    assert trans._client._transport._pool._retries == 5
+    trans.close()
+
+
+def test_socket_options_include_keepalive():
+    """SDK-created clients enable SO_KEEPALIVE on sockets."""
+    import socket as _socket
+
+    trans = HttpTransport(api_token=TEST_TOKEN)
+    pool = trans._client._transport._pool
+    sock_opts = pool._socket_options
+    # SO_KEEPALIVE must always be present
+    assert (_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1) in sock_opts
+    trans.close()
+
+
+def test_granular_timeout_default():
+    """Default timeout uses granular connect/read/write/pool values."""
+    trans = HttpTransport(api_token=TEST_TOKEN)
+    client_timeout = trans._client.timeout
+    assert client_timeout.connect == 10
+    assert client_timeout.read == 30
+    assert client_timeout.write == 10
+    assert client_timeout.pool == 5
+    trans.close()
+
+
+def test_float_timeout_backwards_compat():
+    """Passing a plain float still works (applied to all timeout fields)."""
+    trans = HttpTransport(api_token=TEST_TOKEN, timeout=15.0)
+    client_timeout = trans._client.timeout
+    assert client_timeout.connect == 15.0
+    assert client_timeout.read == 15.0
+    trans.close()
+
+
+def test_httpx_timeout_object_passthrough():
+    """Passing an httpx.Timeout object is used as-is."""
+    custom = httpx.Timeout(connect=3, read=60, write=5, pool=2)
+    trans = HttpTransport(api_token=TEST_TOKEN, timeout=custom)
+    client_timeout = trans._client.timeout
+    assert client_timeout.connect == 3
+    assert client_timeout.read == 60
+    assert client_timeout.pool == 2
+    trans.close()
+
+
+def test_reset_preserves_retries_and_socket_options():
+    """reset() recreates the client with the same retries and socket opts."""
+    import socket as _socket
+
+    trans = HttpTransport(api_token=TEST_TOKEN, retries=4)
+    trans.reset()
+    assert trans._client._transport._pool._retries == 4
+    sock_opts = trans._client._transport._pool._socket_options
+    assert (_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1) in sock_opts
     trans.close()


### PR DESCRIPTION
Add several protections to reduce buildup of consumed networking resources over time when a single long-lived client is in use by an application.

Summary — 6 commits on ibanner56/connection-pool-limits

75 tests pass, 89.8% coverage (up from 53 tests, 84.7%)

```markdown
┌─────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────┐
│ Threat                              │ Mitigation                                                                                   │
├─────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ Unbounded pool / conntrack          │ max_connections=10, max_keepalive_connections=5                                              │
│ saturation                          │                                                                                              │
├─────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ TIME_WAIT buildup                   │ keepalive_expiry=120s maximizes connection reuse; fewer close/reopen cycles                  │
├─────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ Stale keep-alive / dead peers       │ TCP SO_KEEPALIVE + KEEPIDLE=60/INTVL=10/CNT=3 detects dead connections at the kernel level   │
├─────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ DNS resolver exhaustion             │ HTTPTransport(retries=2) retries connect-level failures (DNS + TCP) automatically            │
├─────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ Half-open / idle socket buildup     │ TCP keepalive probes + pool expiry work together — kernel detects dead peers, pool evicts    │
│                                     │ idle connections                                                                             │
├─────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ Connect/pool stalls compounding     │ Timeout(connect=5, pool=5) — worst case with retries is ~15s, not 30s                        │
└─────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────┘
```

Everything is configurable via Client(limits=..., timeout=..., retries=...) and bypassed entirely if you pass your own http_client.
Plain timeout=30.0 (float) still works for backwards compat.
